### PR TITLE
Flag cached result. Limit exception types suppressed.

### DIFF
--- a/lib/checkpoint.rb
+++ b/lib/checkpoint.rb
@@ -35,7 +35,7 @@ module Checkpoint
       mtime = File.mtime(opts[:cache_file]).to_i
       limit = Time.now.to_i - (60 * 60 * 24 * 2)
       if mtime > limit
-        return build_check(File.read(opts[:cache_file]))
+        return build_check(File.read(opts[:cache_file]), "cached" => true)
       end
 
       # Delete the file
@@ -101,7 +101,7 @@ module Checkpoint
     end
 
     build_check(resp.body)
-  rescue Exception
+  rescue StandardError
     # If we want errors, raise it
     raise if opts[:raise_error]
 
@@ -116,9 +116,10 @@ module Checkpoint
 
   protected
 
-  def self.build_check(response)
+  def self.build_check(response, extra_info={})
     JSON.parse(response).tap do |result|
       result["outdated"] = !!result["outdated"]
+      result.merge!(extra_info)
     end
   end
 end

--- a/spec/checkpoint_spec.rb
+++ b/spec/checkpoint_spec.rb
@@ -4,6 +4,10 @@ require "helper"
 
 describe Checkpoint do
   describe ".check" do
+    before do
+      allow(ENV).to receive(:[]).and_return(nil)
+    end
+
     context "with a proper request" do
       subject do
         described_class.check(
@@ -19,23 +23,77 @@ describe Checkpoint do
       its(["product"]) { should eq("test") }
     end
 
-    it "should cache things with cache_file" do
-      tf = Tempfile.new("checkpoint")
-      path = tf.path
-      tf.close
-      File.unlink(path)
+    context "cache file" do
+      let(:path){ @path }
 
-      opts = {
-        product: "test",
-        version: "1.0",
-        cache_file: path,
+      before do
+        tf = Tempfile.new("checkpoint")
+        tfpath = tf.path
+        tf.close
+        File.unlink(tfpath)
+        @path = tfpath
+      end
+
+      after{ File.unlink(path) if File.exist?(path) }
+
+      it "should cache things with cache_file" do
+        opts = {
+          product: "test",
+          version: "1.0",
+          cache_file: path,
+        }
+
+        # Just run it twice
+        c = described_class.check(opts)
+        c = described_class.check(opts)
+
+        expect(c["product"]).to eq("test")
+      end
+
+      it "should indicate cached result" do
+        opts = {
+          product: "test",
+          version: "1.0",
+          cache_file: path,
+        }
+
+        # Just run it twice
+        c = described_class.check(opts)
+        c = described_class.check(opts)
+
+        expect(c["cached"]).to eq(true)
+      end
+    end
+
+    context "with errors" do
+      let(:error_class){ StandardError }
+      let(:opts) {
+        {
+          product: "test",
+          version: "1.0"
+        }
       }
+      before{ allow(Net::HTTP).to receive(:new).and_raise(error_class) }
 
-      # Just run it twice
-      c = described_class.check(opts)
-      c = described_class.check(opts)
+      it "should not raise error by default" do
+        expect(described_class.check(opts)).to be_nil
+      end
 
-      expect(c["product"]).to eq("test")
+      it "should raise error when option set" do
+        expect{ described_class.check(opts.merge(raise_error: true)) }.to raise_error(error_class)
+      end
+
+      context "with non-StandardError descendant exception" do
+        let(:error_class){ Interrupt }
+
+        it "should raise error by default" do
+          expect{ described_class.check(opts) }.to raise_error(error_class)
+        end
+
+        it "should raise error when option set" do
+          expect{ described_class.check(opts.merge(raise_error: true)) }.to raise_error(error_class)
+        end
+      end
     end
 
     it "does not check when CHECKPOINT_DISABLE=1" do


### PR DESCRIPTION
Adds a `cached` key to the result hash to inform user that
result is from local cached value, not new information
received. Also restricts exception suppression to only
StandardError and descendants. This prevents higher level
execeptions like interrupts or memory errors from being
captured.